### PR TITLE
Fix broken drk.py wrapper

### DIFF
--- a/core/drk.py
+++ b/core/drk.py
@@ -21,7 +21,6 @@ def check_open(args, input_string=None):
 
 class Shell(object):
     def check_open(self, args, input_string=None):
-        self.subject.notify(' '.join(args))
         return check_open(args, input_string)
 
 class SecureShell(Shell):


### PR DESCRIPTION
Removed broken 'subject' reference. Evidently I haven't run drk.py for several years.

Thanks to rakeshdhakla@gmail.com for reporting the problem!
