### PR TITLE
Fix drifts in file_operations struct and ioctl function signature

### DIFF
--- a/core/kernel_linux/dynamorio_controller_module.c
+++ b/core/kernel_linux/dynamorio_controller_module.c
@@ -31,9 +31,8 @@ smp_exit(void *info)
     dr_smp_exit();
 }
 
-static int
-init_ioctl(struct inode* inode, struct file* file,
-           unsigned int ioctl_num, unsigned long ioctl_param)
+static long
+init_ioctl(struct file* file, unsigned int ioctl_num, unsigned long ioctl_param)
 {
     dynamorio_init_cmd_t cmd;
     if (initialized) {
@@ -65,9 +64,8 @@ init_ioctl(struct inode* inode, struct file* file,
     return 0;
 }
 
-static int
-exit_ioctl(struct inode* inode, struct file* file,
-           unsigned int ioctl_num, unsigned long ioctl_param)
+static long
+exit_ioctl(struct file* file, unsigned int ioctl_num, unsigned long ioctl_param)
 {
     dynamorio_exit_cmd_t cmd;
     if (!initialized) {
@@ -93,7 +91,7 @@ copy_export_to_user(void *data, unsigned long size, unsigned long max_size,
                     stats_buffer_t *buffer)
 {
     if (size > max_size) {
-        printk("User buffer is too small (%luB) to hold kstats (%luB).\n", 
+        printk("User buffer is too small (%luB) to hold kstats (%luB).\n",
                max_size, size);
         return -EINVAL;
     }
@@ -110,9 +108,8 @@ copy_export_to_user(void *data, unsigned long size, unsigned long max_size,
     return 0;
 }
 
-static int
-kstats_ioctl(struct inode* inode, struct file* file,
-             unsigned int ioctl_num, unsigned long ioctl_param)
+static long
+kstats_ioctl(struct file* file, unsigned int ioctl_num, unsigned long ioctl_param)
 {
     dynamorio_kstats_cmd_t __user *kstats;
     dr_cpu_exports_t *exports;
@@ -148,9 +145,10 @@ kstats_ioctl(struct inode* inode, struct file* file,
                                DYNAMORIO_KSTATS_MAX_SIZE, &kstats->buffer);
 }
 
-static int
-stats_ioctl(struct inode* inode, struct file* file,
-            unsigned int ioctl_num, unsigned long ioctl_param)
+static long
+stats_ioctl(struct file* file,
+            unsigned int ioctl_num,
+            unsigned long ioctl_param)
 {
     dynamorio_stats_cmd_t __user *stats;
     stats = (dynamorio_stats_cmd_t __user *) ioctl_param;
@@ -164,19 +162,20 @@ stats_ioctl(struct inode* inode, struct file* file,
                                DYNAMORIO_STATS_MAX_SIZE, &stats->buffer);
 }
 
-static int device_ioctl(struct inode* inode,
-                        struct file* file,
-                        unsigned int ioctl_num,
-                        unsigned long ioctl_param) {
+static long
+device_ioctl(struct file* file,
+             unsigned int ioctl_num,
+             unsigned long ioctl_param)
+{
     switch (ioctl_num) {
     case DYNAMORIO_IOCTL_INIT:
-        return init_ioctl(inode, file, ioctl_num, ioctl_param);
+        return init_ioctl(file, ioctl_num, ioctl_param);
     case DYNAMORIO_IOCTL_EXIT:
-        return exit_ioctl(inode, file, ioctl_num, ioctl_param);
+        return exit_ioctl(file, ioctl_num, ioctl_param);
     case DYNAMORIO_IOCTL_KSTATS:
-        return kstats_ioctl(inode, file, ioctl_num, ioctl_param);
+        return kstats_ioctl(file, ioctl_num, ioctl_param);
     case DYNAMORIO_IOCTL_STATS:
-        return stats_ioctl(inode, file, ioctl_num, ioctl_param);
+        return stats_ioctl(file, ioctl_num, ioctl_param);
     default:
         printk("Uknwown ioctl number %d.\n", ioctl_num);
     }
@@ -188,7 +187,7 @@ static struct file_operations fops = {
     .write = NULL,
     .open = NULL,
     .release = NULL,
-    .ioctl = device_ioctl,
+    .unlocked_ioctl = device_ioctl,
 };
 
 static int mod_init(void) {

--- a/core/kernel_linux/hypercall_host_module.c
+++ b/core/kernel_linux/hypercall_host_module.c
@@ -59,7 +59,7 @@ static inline queued_hypercall_t* hypercall_queue_consume(hypercall_queue_t* que
     }
 
     // Remove the head.
-    result = list_entry(queue->head.next, queued_hypercall_t, list);    
+    result = list_entry(queue->head.next, queued_hypercall_t, list);
     list_del(&result->list);
     spin_unlock_irqrestore(&queue->lock, flags);
     return result;
@@ -82,7 +82,7 @@ static int clear_queue(hypercall_queue_t* queue) {
     spin_lock_irqsave(&queue->lock, flags);
     while (!list_empty(&queue->head)) {
         queued_hypercall_t* hypercall =
-            list_entry(queue->head.next, queued_hypercall_t, list);    
+            list_entry(queue->head.next, queued_hypercall_t, list);
         list_del(&hypercall->list);
         kfree(hypercall);
     }
@@ -94,7 +94,7 @@ static int hypercall_dequeue_to_user(hypercall_t __user * user_hypercall) {
     size_t failed_bytes;
     queued_hypercall_t* queued;
     hypercall_t* result;
-    
+
     queued = hypercall_queue_consume(&hypercall_queue);
     if (queued == NULL) {
         /* We were interrupted, so return a nop. */
@@ -164,10 +164,9 @@ unsigned long hypercall_handler(
 
 static int device_major;
 
-static int device_ioctl(struct inode* inode,
-                        struct file* file,
-                        unsigned int ioctl_num,
-                        unsigned long ioctl_param) {
+static long device_ioctl(struct file* file,
+                         unsigned int ioctl_num,
+                         unsigned long ioctl_param) {
     void __user *argp = (void __user *)ioctl_param;
     switch (ioctl_num) {
     case HYPERCALL_IOCTL_DEQUEUE:
@@ -186,7 +185,7 @@ static struct file_operations fops = {
     .write = NULL,
     .open = NULL,
     .release = NULL,
-    .ioctl = device_ioctl,
+    .unlocked_ioctl = device_ioctl,
 };
 
 static int hypercall_host_init(void) {


### PR DESCRIPTION
`ioctl` has been removed from the `file_operations` struct since kernel 2.6.36, replaced with `.unlocked_ioctl` and `.compat_ioctl`. Also the signature of `ioctl` functions changed from `int ioctl(struct inode *, struct file *, unsigned int, unsigned long)` to `long ioctl(struct file *, unsigned int, unsigned long)`. This PR updates them to the new definition.