### PR TITLE
i#11: Port `dynamorio` kernel module to Linux 6.6

### DIFF
--- a/core/buildmark.c
+++ b/core/buildmark.c
@@ -34,7 +34,7 @@
 
 #include "globals.h"
 
-#if defined(__DATE__) && defined(__TIME__)
+#if defined(__DATE__) && defined(__TIME__) && !defined(LINUX_KERNEL)
 const char dynamorio_buildmark[] = __DATE__ " " __TIME__;
 #else
 const char dynamorio_buildmark[] = "unknown";

--- a/core/buildmark.c
+++ b/core/buildmark.c
@@ -34,6 +34,9 @@
 
 #include "globals.h"
 
+/* Avoid __DATE__ and __TIME__ in kernel builds to avoid errors from
+ * -Werror=date-time and to support reproducible builds.
+ */
 #if defined(__DATE__) && defined(__TIME__) && !defined(LINUX_KERNEL)
 const char dynamorio_buildmark[] = __DATE__ " " __TIME__;
 #else

--- a/core/configure.h
+++ b/core/configure.h
@@ -87,7 +87,7 @@
 /* #undef DR_DO_NOT_DEFINE_bool */
 /* #undef DR_DO_NOT_DEFINE_byte */
 /* #undef DR_DO_NOT_DEFINE_int64 */
-/* #undef DR_DO_NOT_DEFINE_MAX_MIN */
+#define DR_DO_NOT_DEFINE_MAX_MIN
 /* #undef DR_DO_NOT_DEFINE_sbyte */
 #define DR_DO_NOT_DEFINE_uint
 /* #undef DR_DO_NOT_DEFINE_uint32 */

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1161,7 +1161,7 @@ dynamorio_app_exit(void)
  * does not resume the threads but does release the thread_initexit_lock.
  */
 static void
-synch_with_threads_at_exit(thread_synch_result_t synch_res)
+synch_with_threads_at_exit(thread_synch_state_t synch_res)
 {
     int num_threads;
     thread_record_t **threads;

--- a/core/exports.py
+++ b/core/exports.py
@@ -17,6 +17,8 @@ def check_open(args):
 
 def excluded_functions():
     return {
+        "dr_init",
+        "dr_smp_exit",
         "dr_get_app_PEB",
         "instr_exit_stub_code",
         "dr_syscall_get_result",

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -47,7 +47,11 @@
 #    include "hotpatch.h"
 #endif
 #include "string_wrapper.h" /* for memcpy */
-#include <stddef.h>         /* for offsetof */
+#ifdef LINUX_KERNEL
+#    include <linux/stddef.h> /* for offsetof */
+#else
+#    include <stddef.h> /* for offsetof */
+#endif
 #include "limits_wrapper.h" /* for UCHAR_MAX */
 #include "perscache.h"
 #include "synch.h"

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -47,11 +47,7 @@
 #    include "hotpatch.h"
 #endif
 #include "string_wrapper.h" /* for memcpy */
-#ifdef LINUX_KERNEL
-#    include <linux/stddef.h> /* for offsetof */
-#else
-#    include <stddef.h> /* for offsetof */
-#endif
+#include "stddef_wrapper.h" /* for offsetof */
 #include "limits_wrapper.h" /* for UCHAR_MAX */
 #include "perscache.h"
 #include "synch.h"

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -46,11 +46,7 @@
 #include "monitor.h"
 #include "string_wrapper.h" /* for memset */
 #include "instrument.h"
-#ifdef LINUX_KERNEL
-#    include <linux/stddef.h> /* for offsetof */
-#else
-#    include <stddef.h> /* for offsetof */
-#endif
+#include "stddef_wrapper.h" /* for offsetof */
 #include "limits_wrapper.h" /* UINT_MAX */
 #include "perscache.h"
 #include "synch.h"

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -46,7 +46,11 @@
 #include "monitor.h"
 #include "string_wrapper.h" /* for memset */
 #include "instrument.h"
-#include <stddef.h>         /* for offsetof */
+#ifdef LINUX_KERNEL
+#    include <linux/stddef.h> /* for offsetof */
+#else
+#    include <stddef.h> /* for offsetof */
+#endif
 #include "limits_wrapper.h" /* UINT_MAX */
 #include "perscache.h"
 #include "synch.h"

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -4178,7 +4178,7 @@ fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
 }
 
 /* IBL targeted fragments per branch type */
-fragment_t *
+void
 fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t branch_type)
 {
     per_thread_t *pt = (per_thread_t *)dcontext->fragment_field;
@@ -4216,7 +4216,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                             TABLE_RWLOCK(ibl_table, read, unlock);
                             if (in_persisted_ibl) {
                                 mutex_unlock(&coarse->lock);
-                                return f;
+                                return;
                             }
                         }
                         mutex_unlock(&coarse->lock);
@@ -4284,7 +4284,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
         if (TEST(FRAG_TABLE_SHARED, ibl_table->table_flags) &&
             !TEST(FRAG_SHARED, f->flags)) {
             STATS_INC(num_ibt_shared_private_conflict);
-            return f;
+            return;
         }
 
         ASSERT(TEST(FRAG_IS_TRACE, f->flags) ==
@@ -4415,7 +4415,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
     }
 #endif /* HASHTABLE_STATISTICS */
     DOLOG(4, LOG_FRAGMENT, { dump_lookuptable_tls(dcontext); });
-    return f;
+    return;
 }
 
 /**********************************************************************/

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -689,7 +689,7 @@ void
 fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shift,
                                cache_pc start, cache_pc end, size_t old_size);
 
-fragment_t *
+void
 fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t branch_type);
 
 /* future fragments */

--- a/core/io.c
+++ b/core/io.c
@@ -44,7 +44,11 @@
 #include "globals.h"
 #include "string_wrapper.h"
 #include <linux/kernel.h> // for vsscanf
-#include <stdarg.h>       /* for varargs */
+#ifdef LINUX_KERNEL
+#    include <linux/stdarg.h> /* for varargs */
+#else
+#    include <stdarg.h> /* for varargs */
+#endif
 
 #define VA_ARG_CHAR2INT
 #define BUF_SIZE 64

--- a/core/io.c
+++ b/core/io.c
@@ -378,7 +378,7 @@ our_vsnprintf(char *s, size_t max, const char *fmt, va_list ap)
                                         false);
                     break;
                 }
-                /* note no break */
+                fallthrough;
             case 'x':
             case 'X':
             case 'o':
@@ -437,7 +437,7 @@ our_vsnprintf(char *s, size_t max, const char *fmt, va_list ap)
             case 'G':
                 if (decimal == 0 || decimal == -1)
                     decimal = 1; /* default */
-                /* no break */
+                fallthrough;
             case 'e':
             case 'E':
             case 'f': {

--- a/core/io.c
+++ b/core/io.c
@@ -43,12 +43,8 @@
 
 #include "globals.h"
 #include "string_wrapper.h"
-#include <linux/kernel.h> // for vsscanf
-#ifdef LINUX_KERNEL
-#    include <linux/stdarg.h> /* for varargs */
-#else
-#    include <stdarg.h> /* for varargs */
-#endif
+#include <linux/kernel.h>   // for vsscanf
+#include "stdarg_wrapper.h" /* for varargs */
 
 #define VA_ARG_CHAR2INT
 #define BUF_SIZE 64

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -146,8 +146,10 @@ find_kernel_symbol_address(const char *name)
  * find_kernel_symbol_address. */
 kernel_symbol_t native_load_gs_index_symbol;
 kernel_symbol_t gs_change_symbol;
-static void *(*module_alloc_address)(unsigned long) = NULL;
-static unsigned long (*module_kallsyms_lookup_name_address)(const char *name) = NULL;
+static void *(*module_alloc_ptr)(unsigned long) = NULL;
+static unsigned long (*module_kallsyms_lookup_name_ptr)(const char *name) = NULL;
+static struct module *(*find_module_ptr)(const char *name) = NULL;
+static struct module *(*__module_address_ptr)(unsigned long addr) = NULL;
 
 bool
 kernel_module_init(size_t dr_heap_size)
@@ -168,13 +170,21 @@ kernel_module_init(size_t dr_heap_size)
     if (!find_kernel_symbol(&gs_change_symbol)) {
         return false;
     }
-    module_alloc_address = find_kernel_symbol_address("module_alloc");
-    if (!module_alloc_address) {
+    module_alloc_ptr = find_kernel_symbol_address("module_alloc");
+    if (!module_alloc_ptr) {
         return false;
     }
-    module_kallsyms_lookup_name_address =
+    module_kallsyms_lookup_name_ptr =
         find_kernel_symbol_address("module_kallsyms_lookup_name");
-    if (!module_kallsyms_lookup_name_address) {
+    if (!module_kallsyms_lookup_name_ptr) {
+        return false;
+    }
+    find_module_ptr = find_kernel_symbol_address("find_module");
+    if (!find_module_ptr) {
+        return false;
+    }
+    __module_address_ptr = find_kernel_symbol_address("__module_address");
+    if (!__module_address_ptr) {
         return false;
     }
 
@@ -189,7 +199,7 @@ kernel_module_init(size_t dr_heap_size)
      * are disabled.
      */
     heap_size = dr_heap_size;
-    heap = module_alloc_address(heap_size);
+    heap = module_alloc_ptr(heap_size);
     if (!heap) {
         printk("Failed to allocate %luB using module_alloc.\n", heap_size);
         return false;
@@ -222,17 +232,11 @@ void *
 kernel_load_shared_library(char *name)
 {
     struct module *module;
-    /* We're supposed to lock module_mutex here to use find_module. However, we
-     * are screwed if we have to block because DR code should not be
-     * interrupted. A better hack would be to use mutex_trylock, but the
-     * kernel's module loader links mutex_trylock to the one defined in utils.c,
-     * not one in Linux's linux/mutex.c :-(.
-     */
-    if (mutex_is_locked(&module_mutex)) {
-        DR_ASSERT(false);
-        return NULL;
-    }
-    module = find_module(name);
+
+    rcu_read_lock();
+    module = find_module_ptr(name);
+    rcu_read_unlock();
+
     return module;
 }
 
@@ -254,7 +258,7 @@ kernel_lookup_library_routine(void *lib, char *name)
     qualified_name[strlen(module->name)] = ':';
     strcpy(qualified_name + strlen(module->name) + 1, name);
     DR_ASSERT(qualified_name[qualified_name_len] == '\0');
-    return (void *)module_kallsyms_lookup_name_address(qualified_name);
+    return (void *)module_kallsyms_lookup_name_ptr(qualified_name);
 }
 
 static void
@@ -281,7 +285,7 @@ byte *
 kernel_get_module_base(byte *pc)
 {
     byte *start, *end;
-    struct module *module = __module_address((unsigned long)pc);
+    struct module *module = __module_address_ptr((unsigned long)pc);
     if (module == NULL) {
         return NULL;
     }
@@ -292,10 +296,9 @@ kernel_get_module_base(byte *pc)
 bool
 kernel_find_dynamorio_module_bounds(byte **start, byte **end)
 {
-    const struct kernel_symbol *sym;
     struct module *this_module;
-    sym = find_symbol("dynamorio_dummy_symbol", &this_module, NULL, true, true);
-    if (sym == NULL) {
+    this_module = __module_address_ptr((unsigned long)&dynamorio_dummy_symbol);
+    if (this_module == NULL) {
         return false;
     }
     get_module_bounds(this_module, start, end);

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -77,16 +77,8 @@ done:
     kfree(buffer);
 }
 
-/* The callback function signature was changed in Linux 6.4.0. The module parameter has
- * been removed.
- * https://github.com/torvalds/linux/commit/3703bd54cd37e7875f51ece8df8c85c184e40bba
- */
 static int
-find_kernel_symbol_callback(void *data, const char *name,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-                            struct module *module,
-#endif
-                            unsigned long address)
+find_kernel_symbol_callback(void *data, const char *name, unsigned long address)
 {
     kernel_symbol_t *symbol = (kernel_symbol_t *)data;
     if (strcmp(name, symbol->name) == 0) {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -54,7 +54,7 @@ get_symbol_size(kernel_symbol_t *symbol)
 
     symbol->has_size = false;
     buffer = kmalloc(strlen(symbol->name) + 100, GFP_ATOMIC);
-    if (!buffer) {
+    if (buffer == NULL) {
         goto done;
     }
     sprint_symbol(buffer, symbol->address);
@@ -107,11 +107,11 @@ kernel_find_symbol(const char *name, void **address, size_t *size)
     if (find_kernel_symbol(&symbol)) {
         *address = (void *)symbol.address;
         if (symbol.has_size) {
-            if (size) {
+            if (size != NULL) {
                 *size = symbol.size;
             }
         } else {
-            if (size) {
+            if (size != NULL) {
                 *size = 0;
             }
         }
@@ -163,20 +163,20 @@ kernel_module_init(size_t dr_heap_size)
         return false;
     }
     module_alloc_ptr = find_kernel_symbol_address("module_alloc");
-    if (!module_alloc_ptr) {
+    if (module_alloc_ptr == NULL) {
         return false;
     }
     module_kallsyms_lookup_name_ptr =
         find_kernel_symbol_address("module_kallsyms_lookup_name");
-    if (!module_kallsyms_lookup_name_ptr) {
+    if (module_kallsyms_lookup_name_ptr == NULL) {
         return false;
     }
     find_module_ptr = find_kernel_symbol_address("find_module");
-    if (!find_module_ptr) {
+    if (find_module_ptr == NULL) {
         return false;
     }
     __module_address_ptr = find_kernel_symbol_address("__module_address");
-    if (!__module_address_ptr) {
+    if (__module_address_ptr == NULL) {
         return false;
     }
 
@@ -192,7 +192,7 @@ kernel_module_init(size_t dr_heap_size)
      */
     heap_size = dr_heap_size;
     heap = module_alloc_ptr(heap_size);
-    if (!heap) {
+    if (heap == NULL) {
         printk("Failed to allocate %luB using module_alloc.\n", heap_size);
         return false;
         ;
@@ -326,14 +326,14 @@ static void
 assert_heap_mapped(void *heap, size_t size)
 {
     struct task_struct *g, *p;
-    /* The Linux kernel stores the task list as an RCU-protected linked list. 
+    /* The Linux kernel stores the task list as an RCU-protected linked list.
      * for_each_process_thread requires the RCU read lock to safely traverse all threads.
      * See https://docs.kernel.org/6.6/RCU/listRCU.html */
     rcu_read_lock();
     for_each_process_thread(g, p)
     {
         vm_region_t region;
-        if (!p->mm) {
+        if (p->mm == NULL) {
             continue;
         }
         DR_ASSERT(p->mm->pgd);

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -7,7 +7,6 @@
 #include <linux/kallsyms.h>
 #include <linux/sched.h>
 #include <linux/mm.h>
-#include <linux/version.h>
 
 #include "dynamorio_module_interface.h"
 #include "dynamorio_module_assert_interface.h"

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -7,6 +7,7 @@
 #include <linux/kallsyms.h>
 #include <linux/sched.h>
 #include <linux/mm.h>
+#include <linux/version.h>
 
 #include "dynamorio_module_interface.h"
 #include "dynamorio_module_assert_interface.h"
@@ -39,7 +40,6 @@ zero_cpu_private_data(void)
 
 typedef struct {
     unsigned long address;
-    struct module *module;
     bool has_size;
     size_t size;
     const char *name;
@@ -77,13 +77,19 @@ done:
     kfree(buffer);
 }
 
+/* The callback function signature was changed in Linux 6.4.0. The module parameter has
+ * been removed.
+ * https://github.com/torvalds/linux/commit/3703bd54cd37e7875f51ece8df8c85c184e40bba
+ */
 static int
-find_kernel_sybmol_callback(void *data, const char *name, struct module *module,
+find_kernel_symbol_callback(void *data, const char *name,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+                            struct module *module,
+#endif
                             unsigned long address)
 {
     kernel_symbol_t *symbol = (kernel_symbol_t *)data;
     if (strcmp(name, symbol->name) == 0) {
-        symbol->module = module;
         symbol->address = address;
         get_symbol_size(symbol);
         return 1;
@@ -94,7 +100,7 @@ find_kernel_sybmol_callback(void *data, const char *name, struct module *module,
 static bool
 find_kernel_symbol(kernel_symbol_t *symbol)
 {
-    if (kallsyms_on_each_symbol(find_kernel_sybmol_callback, symbol)) {
+    if (kallsyms_on_each_symbol(find_kernel_symbol_callback, symbol)) {
         return true;
     }
     printk("find_kernel_symbol failed for %s\n", symbol->name);

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -299,7 +299,7 @@ byte *
 kernel_get_module_base(byte *pc)
 {
     /* We always return the start of the core text segment as the 'base address' to ensure
-     * consistency for symbol offsets, even if the PC is in a data segment.
+     * consistency for symbol offsets, even if the PC is not in the core text segment.
      * TODO: maybe rename this function to make this more obvious.
      */
     struct module *module = __module_address_ptr((unsigned long)pc);

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -225,6 +225,8 @@ kernel_load_shared_library(char *name)
 {
     struct module *module;
 
+    /* The Linux kernel stores loaded modules as an RCU-protected linked list.
+     * find_module requires the RCU read lock to safely traverse it. */
     rcu_read_lock();
     module = find_module_ptr(name);
     rcu_read_unlock();

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -275,6 +275,9 @@ get_module_bounds(struct module *module, byte *addr, byte **start, byte **end)
     }
 
     /* Fallback to text segment if address not found in any segment (shouldn't happen?) */
+    pr_warn("drk: Address %p not found for any segment for module %s. Falling back to "
+            "text segment.\n",
+            addr, module->name);
     *start = (byte *)module->mem[MOD_TEXT].base;
     *end = (byte *)module->mem[MOD_TEXT].base + module->mem[MOD_TEXT].size;
 }

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -304,8 +304,8 @@ kernel_get_module_text_base(byte *pc)
 bool
 kernel_find_dynamorio_module_bounds(byte **start, byte **end)
 {
-    // TODO: once the module is running we should test whether the following logic can be
-    // simplified using the THIS_MODULE macro.
+    // TODO i#11: once the module is running we should test whether the following logic
+    // can be simplified using the THIS_MODULE macro.
     struct module *this_module;
     this_module = __module_address_ptr((unsigned long)&dynamorio_dummy_symbol);
     if (this_module == NULL) {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -262,10 +262,21 @@ kernel_lookup_library_routine(void *lib, char *name)
 }
 
 static void
-get_module_bounds(struct module *module, byte **start, byte **end)
+get_module_bounds(struct module *module, byte *addr, byte **start, byte **end)
 {
-    *start = (byte *)module->module_core;
-    *end = (byte *)module->module_core + module->core_size;
+    for (int i = 0; i < MOD_MEM_NUM_TYPES; i++) {
+        unsigned long base = (unsigned long)module->mem[i].base;
+        unsigned long size = module->mem[i].size;
+        if ((unsigned long)addr >= base && (unsigned long)addr < base + size) {
+            *start = (byte *)base;
+            *end = (byte *)base + size;
+            return;
+        }
+    }
+
+    /* Fallback to text segment if address not found in any segment (shouldn't happen?) */
+    *start = (byte *)module->mem[MOD_TEXT].base;
+    *end = (byte *)module->mem[MOD_TEXT].base + module->mem[MOD_TEXT].size;
 }
 
 bool
@@ -276,7 +287,7 @@ kernel_shared_library_bounds(void *lib, byte *addr, byte **start, byte **end)
     if (module == NULL) {
         return false;
     }
-    get_module_bounds(module, start, end);
+    get_module_bounds(module, addr, start, end);
     DR_ASSERT(addr >= *start && addr < *end);
     return true;
 }
@@ -284,13 +295,15 @@ kernel_shared_library_bounds(void *lib, byte *addr, byte **start, byte **end)
 byte *
 kernel_get_module_base(byte *pc)
 {
-    byte *start, *end;
+    /* We always return the start of the core text segment as the 'base address' to ensure
+     * consistency for symbol offsets, even if the PC is in a data segment.
+     * TODO: maybe rename this function to make this more obvious.
+     */
     struct module *module = __module_address_ptr((unsigned long)pc);
     if (module == NULL) {
         return NULL;
     }
-    get_module_bounds(module, &start, &end);
-    return start;
+    return (byte *)module->mem[MOD_TEXT].base;
 }
 
 bool
@@ -303,7 +316,12 @@ kernel_find_dynamorio_module_bounds(byte **start, byte **end)
     if (this_module == NULL) {
         return false;
     }
-    get_module_bounds(this_module, start, end);
+
+    /* For DynamoRIO's own bounds, we return the text segment. DR uses this to identify
+     * its own code for exclusion from instrumentation.
+     */
+    *start = (byte *)this_module->mem[MOD_TEXT].base;
+    *end = (byte *)this_module->mem[MOD_TEXT].base + this_module->mem[MOD_TEXT].size;
     return true;
 }
 

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -329,7 +329,8 @@ static void
 assert_heap_mapped(void *heap, size_t size)
 {
     struct task_struct *g, *p;
-    do_each_thread(g, p)
+    rcu_read_lock();
+    for_each_process_thread(g, p)
     {
         vm_region_t region;
         if (!p->mm) {
@@ -344,7 +345,7 @@ assert_heap_mapped(void *heap, size_t size)
         DR_ASSERT(region.access.executable);
         DR_ASSERT(!region.access.user);
     }
-    while_each_thread(g, p);
+    rcu_read_unlock();
 }
 
 void *

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -289,11 +289,10 @@ kernel_shared_library_bounds(void *lib, byte *addr, byte **start, byte **end)
 }
 
 byte *
-kernel_get_module_base(byte *pc)
+kernel_get_module_text_base(byte *pc)
 {
     /* We always return the start of the core text segment as the 'base address' to ensure
      * consistency for symbol offsets, even if the PC is not in the core text segment.
-     * TODO: maybe rename this function to make this more obvious.
      */
     struct module *module = __module_address_ptr((unsigned long)pc);
     if (module == NULL) {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -326,6 +326,9 @@ static void
 assert_heap_mapped(void *heap, size_t size)
 {
     struct task_struct *g, *p;
+    /* The Linux kernel stores the task list as an RCU-protected linked list. 
+     * for_each_process_thread requires the RCU read lock to safely traverse all threads.
+     * See https://docs.kernel.org/6.6/RCU/listRCU.html */
     rcu_read_lock();
     for_each_process_thread(g, p)
     {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -296,6 +296,8 @@ kernel_get_module_base(byte *pc)
 bool
 kernel_find_dynamorio_module_bounds(byte **start, byte **end)
 {
+    // TODO: once the module is running we should test whether the following logic can be
+    // simplified using the THIS_MODULE macro.
     struct module *this_module;
     this_module = __module_address_ptr((unsigned long)&dynamorio_dummy_symbol);
     if (this_module == NULL) {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -383,7 +383,7 @@ kernel_get_present_processor_count()
 void
 kernel_init_cpu_private_data(size_t *size, size_t *gs_offset)
 {
-    *gs_offset = (size_t)&per_cpu_var(dynamorio_page);
+    *gs_offset = (size_t)&dynamorio_page;
     *size = sizeof(struct dynamorio_page);
 }
 

--- a/core/kernel_linux/kernel_interface.h
+++ b/core/kernel_linux/kernel_interface.h
@@ -74,6 +74,6 @@ kernel_lookup_library_routine(void *lib, char *name);
 bool
 kernel_shared_library_bounds(void *lib, byte *addr, byte **start, byte **end);
 byte *
-kernel_get_module_base(byte *pc);
+kernel_get_module_text_base(byte *pc);
 
 #endif

--- a/core/kernel_linux/modules/Makefile
+++ b/core/kernel_linux/modules/Makefile
@@ -21,66 +21,63 @@ EXTRA_AFLAGS=$(DR_INCLUDE_FLAGS)\
 ## ../../kernel_linux/simple_tests.o
 ################################################################################
 
-################################################################################
-## TODO i#11: Re-enable this module once the previous module is building.
-## 	obj-m += dynamorio.o
-## 	dynamorio-objs :=\
-## ../../exports.o\
-## ../../buildmark.o\
-## ../../config.o\
-## ../../dispatch.o\
-## ../../dynamo.o\
-## ../../emit.o\
-## ../../fcache.o\
-## ../../fragment.o\
-## ../../hashtable.o\
-## ../../heap.o\
-## ../../hotpatch.o\
-## ../../instrlist.o\
-## ../../io.o\
-## ../../link.o\
-## ../../loader_shared.o\
-## ../../moduledb.o\
-## ../../module_list.o\
-## ../../monitor.o\
-## ../../nudge.o\
-## ../../options.o\
-## ../../perfctr.o\
-## ../../perscache.o\
-## ../../rct.o\
-## ../../stats.o\
-## ../../synch.o\
-## ../../unit-rct.o\
-## ../../utils.o\
-## ../../barrier.o\
-## ../../vmareas.o\
-## ../../x86/arch.o\
-## ../../x86/decode.o\
-## ../../x86/decode_fast.o\
-## ../../x86/decode_table.o\
-## ../../x86/disassemble.o\
-## ../../x86/emit_utils.o\
-## ../../x86/encode.o\
-## ../../x86/instr.o\
-## ../../x86/instrument.o\
-## ../../x86/interp.o\
-## ../../x86/loadtoconst.o\
-## ../../x86/mangle.o\
-## ../../x86/optimize.o\
-## ../../x86/proc.o\
-## ../../x86/retcheck.o\
-## ../../x86/sideline.o\
-## ../../x86/steal_reg.o\
-## ../../x86/x86_code.o\
-## ../../x86/asm_defines.o\
-## ../../x86/x86.o\
-## ../../kernel_linux/os.o\
-## ../../kernel_linux/hypercall_guest.o\
-## ../../kernel_linux/page_table.o\
-## ../../kernel_linux/kernel_interface.o\
-## ../../kernel_linux/dynamorio_module_interface.o\
-## ../../kernel_linux/dynamorio_module.o
-################################################################################
+	obj-m += dynamorio.o
+	dynamorio-objs :=\
+../../exports.o\
+../../buildmark.o\
+../../config.o\
+../../dispatch.o\
+../../dynamo.o\
+../../emit.o\
+../../fcache.o\
+../../fragment.o\
+../../hashtable.o\
+../../heap.o\
+../../hotpatch.o\
+../../instrlist.o\
+../../io.o\
+../../link.o\
+../../loader_shared.o\
+../../moduledb.o\
+../../module_list.o\
+../../monitor.o\
+../../nudge.o\
+../../options.o\
+../../perfctr.o\
+../../perscache.o\
+../../rct.o\
+../../stats.o\
+../../synch.o\
+../../unit-rct.o\
+../../utils.o\
+../../barrier.o\
+../../vmareas.o\
+../../x86/arch.o\
+../../x86/decode.o\
+../../x86/decode_fast.o\
+../../x86/decode_table.o\
+../../x86/disassemble.o\
+../../x86/emit_utils.o\
+../../x86/encode.o\
+../../x86/instr.o\
+../../x86/instrument.o\
+../../x86/interp.o\
+../../x86/loadtoconst.o\
+../../x86/mangle.o\
+../../x86/optimize.o\
+../../x86/proc.o\
+../../x86/retcheck.o\
+../../x86/sideline.o\
+../../x86/steal_reg.o\
+../../x86/x86_code.o\
+../../x86/asm_defines.o\
+../../x86/x86.o\
+../../kernel_linux/os.o\
+../../kernel_linux/hypercall_guest.o\
+../../kernel_linux/page_table.o\
+../../kernel_linux/kernel_interface.o\
+../../kernel_linux/dynamorio_module_interface.o\
+../../kernel_linux/dynamorio_module.o
 
 ################################################################################
 ## TODO i#11: Re-enable this module once the previous modules are building.

--- a/core/kernel_linux/os.c
+++ b/core/kernel_linux/os.c
@@ -237,7 +237,7 @@ get_module_company_name(app_pc mod_base, char *out_buf, size_t out_buf_size)
 app_pc
 get_module_base(app_pc pc)
 {
-    return kernel_get_module_base(pc);
+    return kernel_get_module_text_base(pc);
 }
 
 bool

--- a/core/kernel_linux/os_exports.h
+++ b/core/kernel_linux/os_exports.h
@@ -41,7 +41,11 @@
 #ifndef _OS_EXPORTS_H_
 #define _OS_EXPORTS_H_ 1
 
-#include <stdarg.h>
+#ifdef LINUX_KERNEL
+#    include <linux/stdarg.h>
+#else
+#    include <stdarg.h>
+#endif
 #include "../os_shared.h"
 #include "arch_exports.h"
 

--- a/core/kernel_linux/os_exports.h
+++ b/core/kernel_linux/os_exports.h
@@ -123,7 +123,11 @@ process_id_t
 get_parent_id(void);
 
 /* to avoid transparency problems we must have our own vnsprintf */
-#include <stdarg.h> /* for va_list */
+#ifdef LINUX_KERNEL
+#    include <linux/stdarg.h> /* for va_list */
+#else
+#    include <stdarg.h> /* for va_list */
+#endif
 int
 our_snprintf(char *s, size_t max, const char *fmt, ...);
 int

--- a/core/kernel_linux/os_exports.h
+++ b/core/kernel_linux/os_exports.h
@@ -41,11 +41,7 @@
 #ifndef _OS_EXPORTS_H_
 #define _OS_EXPORTS_H_ 1
 
-#ifdef LINUX_KERNEL
-#    include <linux/stdarg.h>
-#else
-#    include <stdarg.h>
-#endif
+#include <stdarg_wrapper.h>
 #include "../os_shared.h"
 #include "arch_exports.h"
 

--- a/core/kernel_linux/os_exports.h
+++ b/core/kernel_linux/os_exports.h
@@ -123,11 +123,6 @@ process_id_t
 get_parent_id(void);
 
 /* to avoid transparency problems we must have our own vnsprintf */
-#ifdef LINUX_KERNEL
-#    include <linux/stdarg.h> /* for va_list */
-#else
-#    include <stdarg.h> /* for va_list */
-#endif
 int
 our_snprintf(char *s, size_t max, const char *fmt, ...);
 int

--- a/core/kernel_linux/os_exports.h
+++ b/core/kernel_linux/os_exports.h
@@ -41,7 +41,7 @@
 #ifndef _OS_EXPORTS_H_
 #define _OS_EXPORTS_H_ 1
 
-#include <stdarg_wrapper.h>
+#include "stdarg_wrapper.h"
 #include "../os_shared.h"
 #include "arch_exports.h"
 

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -121,7 +121,9 @@
 #    endif
 #    define LINK_ONCE __attribute__((weak))
 #    define ALIGN_VAR(x) __attribute__((aligned(x)))
-#    define inline __inline__
+#    ifndef LINUX_KERNEL
+#        define inline __inline__
+#    endif
 #    define INLINE_FORCED inline
 #endif
 

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -121,7 +121,7 @@
 #    endif
 #    define LINK_ONCE __attribute__((weak))
 #    define ALIGN_VAR(x) __attribute__((aligned(x)))
-#    ifndef LINUX_KERNEL
+#    ifndef inline
 #        define inline __inline__
 #    endif
 #    define INLINE_FORCED inline

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1665,4 +1665,14 @@ typedef struct _dr_mcontext_t {
 #    define EOF (-1)
 #endif
 
+#ifndef fallthrough
+#    if defined(__GNUC__) && __GNUC__ >= 7
+#        define fallthrough __attribute__((fallthrough))
+#    else
+#        define fallthrough \
+            do {            \
+            } while (0) /* fallthrough */
+#    endif
+#endif
+
 #endif /* ifndef _GLOBALS_SHARED_H_ */

--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -1199,16 +1199,16 @@ STATS_DEF("Nudges", num_nudges)
 STATS_DEF("Doubled-up nudges", num_pending_nudges)
 
 #ifdef LINUX_KERNEL
-STATS_DEF("system call entries", num_syscalls);
-STATS_DEF("interrupt exits handled by dispatcher", num_exits_interrupts);
-STATS_DEF("interrupt patches", num_fragment_interrupt_patches);
-STATS_DEF("interrupt entries", num_interrupts);
-STATS_DEF("interrupt entries", num_user_interrupts);
-STATS_DEF("interrupts in ibl", num_ibl_interrupts);
-STATS_DEF("interrupts in fcache enter", num_fcache_enter_interrupts);
-STATS_DEF("interrupts in fcache return", num_fcache_return_interrupts);
-STATS_DEF("interrupts in fragments (delayed)", num_delayed_frag_intr);
-STATS_DEF("interrupts in fragments (not delayed)", num_ndelayed_frag_intr);
-STATS_DEF("swapgs in user interrupt handler", num_intr_swap_gs_user);
-STATS_DEF("swapgs in kernel interrupt handler", num_intr_swap_gs_kernel);
+STATS_DEF("system call entries", num_syscalls)
+STATS_DEF("interrupt exits handled by dispatcher", num_exits_interrupts)
+STATS_DEF("interrupt patches", num_fragment_interrupt_patches)
+STATS_DEF("interrupt entries", num_interrupts)
+STATS_DEF("interrupt entries", num_user_interrupts)
+STATS_DEF("interrupts in ibl", num_ibl_interrupts)
+STATS_DEF("interrupts in fcache enter", num_fcache_enter_interrupts)
+STATS_DEF("interrupts in fcache return", num_fcache_return_interrupts)
+STATS_DEF("interrupts in fragments (delayed)", num_delayed_frag_intr)
+STATS_DEF("interrupts in fragments (not delayed)", num_ndelayed_frag_intr)
+STATS_DEF("swapgs in user interrupt handler", num_intr_swap_gs_user)
+STATS_DEF("swapgs in kernel interrupt handler", num_intr_swap_gs_kernel)
 #endif

--- a/core/limits_wrapper.h
+++ b/core/limits_wrapper.h
@@ -28,11 +28,4 @@
 #    define CHAR_MAX SCHAR_MAX
 #endif
 
-/* Minimum and maximum values a `signed short int' can hold.  */
-#define SHRT_MIN (-32768)
-#define SHRT_MAX 32767
-
-/* Maximum value an `unsigned short int' can hold.  (Minimum is 0.)  */
-#define USHRT_MAX 65535
-
 #endif

--- a/core/options.c
+++ b/core/options.c
@@ -651,7 +651,7 @@ get_pcache_dynamo_options_string(options_t *options, char *opstr, int len,
                        description, flag, pcache)                                 \
     {                                                                             \
         if (command_line_option[0] != ' ' && /* not synthethic */                 \
-            OPTION_AFFECTS_PCACHE_##name >= pcache_effect &&                      \
+            (op_pcache_t)OPTION_AFFECTS_PCACHE_##name >= pcache_effect &&         \
             DIFF_##type(options->name, default_options.name)) {                   \
             PRINT_STRING_##type(optionbuff, options->name, command_line_option);  \
             NULL_TERMINATE_BUFFER(optionbuff);                                    \
@@ -674,7 +674,7 @@ has_pcache_dynamo_options(options_t *options, op_pcache_t pcache_effect)
                        description, flag, pcache)                                 \
     {                                                                             \
         if (command_line_option[0] != ' ' && /* not synthethic */                 \
-            OPTION_AFFECTS_PCACHE_##name == pcache_effect &&                      \
+            (op_pcache_t)OPTION_AFFECTS_PCACHE_##name == pcache_effect &&         \
             DIFF_##type(options->name, default_options.name)) {                   \
             return true;                                                          \
         }                                                                         \

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -48,7 +48,11 @@
 #include "synch.h"
 #include "module_shared.h"
 #include "string_wrapper.h" /* for memset */
-#include <stddef.h>         /* for offsetof */
+#ifdef LINUX_KERNEL
+#    include <linux/stddef.h> /* for offsetof */
+#else
+#    include <stddef.h> /* for offsetof */
+#endif
 
 #ifdef DEBUG
 #    include "disassemble.h"

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -48,11 +48,7 @@
 #include "synch.h"
 #include "module_shared.h"
 #include "string_wrapper.h" /* for memset */
-#ifdef LINUX_KERNEL
-#    include <linux/stddef.h> /* for offsetof */
-#else
-#    include <stddef.h> /* for offsetof */
-#endif
+#include "stddef_wrapper.h" /* for offsetof */
 
 #ifdef DEBUG
 #    include "disassemble.h"

--- a/core/stdarg_wrapper.h
+++ b/core/stdarg_wrapper.h
@@ -1,0 +1,12 @@
+#ifndef __STDARG_WRAPPER_H_
+#define __STDARG_WRAPPER_H_
+
+#include "configure.h"
+
+#ifdef LINUX_KERNEL
+#    include <linux/stdarg.h>
+#else
+#    include <stdarg.h>
+#endif
+
+#endif /* __STDARG_WRAPPER_H_ */

--- a/core/stddef_wrapper.h
+++ b/core/stddef_wrapper.h
@@ -1,0 +1,12 @@
+#ifndef __STDDEF_WRAPPER_H_
+#define __STDDEF_WRAPPER_H_
+
+#include "configure.h"
+
+#ifdef LINUX_KERNEL
+#    include <linux/stddef.h>
+#else
+#    include <stddef.h>
+#endif
+
+#endif /* __STDDEF_WRAPPER_H_ */

--- a/core/synch.h
+++ b/core/synch.h
@@ -119,7 +119,8 @@ enum {
      desired_synch_state == THREAD_SYNCH_TERMINATED_AND_CLEANED)
 #define THREAD_SYNCH_IS_TERMINATED(desired_synch_state) \
     (desired_synch_state == THREAD_SYNCH_TERMINATED_AND_CLEANED)
-#define THREAD_SYNCH_SAFE(synch_perm, desired_perm) (synch_perm >= desired_perm)
+#define THREAD_SYNCH_SAFE(synch_perm, desired_perm) \
+    (synch_perm >= (thread_synch_permission_t)desired_perm)
 
 void
 synch_init(void);

--- a/core/utils.c
+++ b/core/utils.c
@@ -1707,7 +1707,7 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
 
 #if defined(DEBUG) || defined(INTERNAL) || defined(CLIENT_INTERFACE)
 #    ifndef LINUX_KERNEL
-/* for printing a float (can't use %f on windows with NOLIBC), NOTE: you must
+/* For printing a float (can't use %f on windows with NOLIBC), NOTE: you must
  * preserve floating point state to call this function!!
  * FIXME : truncates instead of rounding, also negative with width looks funny,
  *         finally width can be one off if negative
@@ -1716,6 +1716,7 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
  * note that %f is eqv. to %.6f
  * "%.pf", a => dp(a, p, &c, &d, &s) "%s%u.%.pu", s, c, d
  * "%w.pf", a => dp(a, p, &c, &d, &s) "%s%(w-p-1)u.%.pu", s, c, d
+ * Disabled for Linux kernel because floating-point operations are restricted.
  */
 void
 double_print(double val, uint precision, uint *top, uint *bottom, char **sign)
@@ -4008,6 +4009,7 @@ profile_callers_exit()
 
 #endif /* CALL_PROFILE */
 
+/* Disabled for Linux kernel because floating-point operations are restricted. */
 #if defined(UTILS_UNIT_TEST) && !defined(LINUX_KERNEL)
 
 #    ifdef printf

--- a/core/utils.c
+++ b/core/utils.c
@@ -78,11 +78,7 @@
 #    include "synch.h" /* all_threads_synch_lock */
 #endif
 
-#ifdef LINUX_KERNEL
-#    include <linux/stdarg.h> /* for varargs */
-#else
-#    include <stdarg.h> /* for varargs */
-#endif
+#include "stdarg_wrapper.h" /* for varargs */
 
 #ifdef LINUX_KERNEL
 #    include <linux/ctype.h>

--- a/core/utils.c
+++ b/core/utils.c
@@ -78,7 +78,11 @@
 #    include "synch.h" /* all_threads_synch_lock */
 #endif
 
-#include <stdarg.h> /* for varargs */
+#ifdef LINUX_KERNEL
+#    include <linux/stdarg.h> /* for varargs */
+#else
+#    include <stdarg.h> /* for varargs */
+#endif
 
 #ifdef LINUX_KERNEL
 #    include <linux/ctype.h>

--- a/core/utils.c
+++ b/core/utils.c
@@ -1706,6 +1706,7 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
 }
 
 #if defined(DEBUG) || defined(INTERNAL) || defined(CLIENT_INTERFACE)
+#    ifndef LINUX_KERNEL
 /* for printing a float (can't use %f on windows with NOLIBC), NOTE: you must
  * preserve floating point state to call this function!!
  * FIXME : truncates instead of rounding, also negative with width looks funny,
@@ -1732,7 +1733,8 @@ double_print(double val, uint precision, uint *top, uint *bottom, char **sign)
     *top = (uint)val;
     *bottom = (uint)((val - *top) * precision_multiple);
 }
-#endif /* DEBUG || INTERNAL */
+#    endif /* !LINUX_KERNEL */
+#endif     /* DEBUG || INTERNAL */
 
 #ifdef WINDOWS
 /* for pre_inject, injector, and core shared files, is just wrapper for syslog
@@ -4006,7 +4008,7 @@ profile_callers_exit()
 
 #endif /* CALL_PROFILE */
 
-#ifdef UTILS_UNIT_TEST
+#if defined(UTILS_UNIT_TEST) && !defined(LINUX_KERNEL)
 
 #    ifdef printf
 #        undef printf

--- a/core/utils.h
+++ b/core/utils.h
@@ -2102,6 +2102,7 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
                     uint *top, uint *bottom);
 
 #if defined(DEBUG) || defined(INTERNAL) || defined(CLIENT_INTERFACE)
+#    ifndef LINUX_KERNEL
 /* for printing a float (can't use %f on windows with NOLIBC), NOTE: you must
  * preserve floating point state to call this function!!
  * Usage : given double/float a; uint c, d and char *s tmp; dp==double_print
@@ -2112,7 +2113,8 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
  */
 void
 double_print(double val, uint precision, uint *top, uint *bottom, char **sign);
-#endif /* DEBUG || INTERNAL */
+#    endif /* !LINUX_KERNEL */
+#endif     /* DEBUG || INTERNAL */
 
 #ifdef CALL_PROFILE
 /* Max depth of call stack to maintain.

--- a/core/utils.h
+++ b/core/utils.h
@@ -2103,13 +2103,14 @@ divide_uint64_print(uint64 numerator, uint64 denominator, bool percentage, uint 
 
 #if defined(DEBUG) || defined(INTERNAL) || defined(CLIENT_INTERFACE)
 #    ifndef LINUX_KERNEL
-/* for printing a float (can't use %f on windows with NOLIBC), NOTE: you must
+/* For printing a float (can't use %f on windows with NOLIBC), NOTE: you must
  * preserve floating point state to call this function!!
  * Usage : given double/float a; uint c, d and char *s tmp; dp==double_print
  *         parameterized on precision p width w
  * note that %f is eqv. to %.6f
  * "%.pf", a => dp(a, p, &c, &d, &s) "%s%u.%.pu", s, c, d
  * "%w.pf", a => dp(a, p, &c, &d, &s) "%s%(w-p)u.%.pu", s, c, d
+ * Disabled for Linux kernel because floating-point operations are restricted.
  */
 void
 double_print(double val, uint precision, uint *top, uint *bottom, char **sign);

--- a/core/x86/arch.c
+++ b/core/x86/arch.c
@@ -465,7 +465,7 @@ arch_init()
 {
     ASSERT(sizeof(opnd_t) == EXPECTED_SIZEOF_OPND);
     /* ensure our flag sharing is done properly */
-    ASSERT(LINK_FINAL_INSTR_SHARED_FLAG < INSTR_FIRST_NON_LINK_SHARED_FLAG);
+    ASSERT((uint)LINK_FINAL_INSTR_SHARED_FLAG < (uint)INSTR_FIRST_NON_LINK_SHARED_FLAG);
     ASSERT_TRUNCATE(byte, byte, OPSZ_LAST_ENUM);
     DODEBUG({ reg_check_reg_fixer(); });
 

--- a/core/x86/arch.h
+++ b/core/x86/arch.h
@@ -43,8 +43,12 @@
 #ifndef X86_ARCH_H
 #define X86_ARCH_H
 
-#include <stddef.h> /* for offsetof */
-#include "instr.h"  /* for reg_id_t */
+#ifdef LINUX_KERNEL
+#    include <linux/stddef.h> /* for offsetof */
+#else
+#    include <stddef.h> /* for offsetof */
+#endif
+#include "instr.h" /* for reg_id_t */
 
 /* FIXME: check on all platforms: these are for Fedora 8 and XP SP2
  * Keep in synch w/ defines in pre_inject_asm.asm

--- a/core/x86/arch.h
+++ b/core/x86/arch.h
@@ -43,12 +43,8 @@
 #ifndef X86_ARCH_H
 #define X86_ARCH_H
 
-#ifdef LINUX_KERNEL
-#    include <linux/stddef.h> /* for offsetof */
-#else
-#    include <stddef.h> /* for offsetof */
-#endif
-#include "instr.h" /* for reg_id_t */
+#include "stddef_wrapper.h" /* for offsetof */
+#include "instr.h"          /* for reg_id_t */
 
 /* FIXME: check on all platforms: these are for Fedora 8 and XP SP2
  * Keep in synch w/ defines in pre_inject_asm.asm

--- a/core/x86/decode.c
+++ b/core/x86/decode.c
@@ -1207,7 +1207,7 @@ decode_operand(decode_info_t *di, byte optype, opnd_size_t opsize, opnd_t *opnd)
         /* ensure referencing memory */
         if (di->mod >= 3)
             return false;
-        /* fall through */
+        fallthrough;
     case TYPE_E:
     case TYPE_Q:
     case TYPE_W: return decode_modrm(di, optype, opsize, NULL, opnd);

--- a/core/x86/decode_fast.c
+++ b/core/x86/decode_fast.c
@@ -451,9 +451,7 @@ decode_sizeof(dcontext_t *dcontext, byte *start_pc,
                 sz += 1;
                 break;
             case 0xf2:
-            case 0xf3: /* REP */
-                rep_prefix = true;
-                /* fall through */
+            case 0xf3: /* REP */ rep_prefix = true; fallthrough;
             case 0xf0: /* LOCK */
             case 0x64:
             case 0x65: /* segment overrides */

--- a/core/x86/disassemble.c
+++ b/core/x86/disassemble.c
@@ -232,8 +232,8 @@ opnd_disassemble(dcontext_t *dcontext, opnd_t opnd, file_t outfile)
             print_file(outfile, "%s%s%u.%.6u%s", immed_prefix(), sign, top, bottom,
                        postop_suffix());
         });
-        break;
 #    endif
+        break;
     }
     case PC_kind: {
         app_pc target = opnd_get_pc(opnd);

--- a/core/x86/disassemble.c
+++ b/core/x86/disassemble.c
@@ -435,9 +435,7 @@ opnd_disassemble(dcontext_t *dcontext, opnd_t opnd, file_t outfile)
         break;
     case BASE_DISP_kind: opnd_base_disp_disassemble(dcontext, opnd, outfile); break;
 #    ifdef X64
-    case REL_ADDR_kind:
-        print_file(outfile, "<rel> ");
-        /* fall-through */
+    case REL_ADDR_kind: print_file(outfile, "<rel> "); fallthrough;
     case ABS_ADDR_kind:
         opnd_mem_disassemble_prefix(dcontext, opnd, outfile);
         if (opnd_get_segment(opnd) != REG_NULL)
@@ -634,7 +632,8 @@ opnd_disassemble_intel(dcontext_t *dcontext, file_t outfile, instr_t *instr, byt
             /* if has implicit st0 then don't print it */
             (opnd_get_reg(opnd) == REG_ST0 && instr_memory_reference_size(instr) > 0))
             return false;
-        /* else fall through */
+        else
+            fallthrough;
     case TYPE_A:
     case TYPE_C:
     case TYPE_D:
@@ -668,6 +667,7 @@ opnd_disassemble_intel(dcontext_t *dcontext, file_t outfile, instr_t *instr, byt
             reg_disassemble(outfile, opnd_get_segment(opnd), "", postop_suffix());
             return true;
         }
+        return false;
     default:
         /* implicit operand */
         return false;

--- a/core/x86/encode.c
+++ b/core/x86/encode.c
@@ -1575,7 +1575,7 @@ encode_operand(decode_info_t *di, int optype, opnd_size_t opsize, opnd_t opnd)
     case TYPE_M:
         CLIENT_ASSERT(opnd_is_memory_reference(opnd),
                       "encode error: M operand must be mem ref");
-        /* fall through */
+        fallthrough;
     case TYPE_INDIR_E:
     case TYPE_E:
     case TYPE_Q:

--- a/core/x86/instrument.c
+++ b/core/x86/instrument.c
@@ -52,12 +52,8 @@
 #include "../link.h"
 #include "../monitor.h"     /* for mark_trace_head */
 #include "string_wrapper.h" /* for strstr */
-#ifdef LINUX_KERNEL
-#    include <linux/stdarg.h> /* for varargs */
-#else
-#    include <stdarg.h> /* for varargs */
-#endif
-#include "../nudge.h" /* for nudge_internal() */
+#include "stdarg_wrapper.h" /* for varargs */
+#include "../nudge.h"       /* for nudge_internal() */
 #include "../synch.h"
 #include "barrier.h"
 #ifdef LINUX

--- a/core/x86/instrument.c
+++ b/core/x86/instrument.c
@@ -52,8 +52,12 @@
 #include "../link.h"
 #include "../monitor.h"     /* for mark_trace_head */
 #include "string_wrapper.h" /* for strstr */
-#include <stdarg.h>         /* for varargs */
-#include "../nudge.h"       /* for nudge_internal() */
+#ifdef LINUX_KERNEL
+#    include <linux/stdarg.h> /* for varargs */
+#else
+#    include <stdarg.h> /* for varargs */
+#endif
+#include "../nudge.h" /* for nudge_internal() */
 #include "../synch.h"
 #include "barrier.h"
 #ifdef LINUX

--- a/core/x86/interp.c
+++ b/core/x86/interp.c
@@ -5658,7 +5658,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
 {
     instr_t *inst, *next_inst, *start_instr, *jmp;
     uint blk, num_exits_deleted;
-    app_pc fallthrough = NULL;
+    app_pc fallthrough_pc = NULL;
     bool found_syscall = false, found_int = false;
     int i;
 
@@ -5756,7 +5756,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
 
         /* in case no exit ctis in last block, find last non-meta fall-through */
         if (blk == md->num_blks - 1)
-            fallthrough = instr_get_translation(inst) + instr_length(dcontext, inst);
+            fallthrough_pc = instr_get_translation(inst) + instr_length(dcontext, inst);
 
         /* PR 299808: identify bb boundaries.  We can't go by translations alone, as
          * ubrs can point at their targets and theoretically the entire trace could
@@ -5830,7 +5830,7 @@ mangle_trace(dcontext_t *dcontext, instrlist_t *ilist, monitor_data_t *md)
             return false;
         }
         /* must have been no final exit cti: add final fall-through jmp */
-        jmp = create_exit_jmp(dcontext, fallthrough, fallthrough, 0);
+        jmp = create_exit_jmp(dcontext, fallthrough_pc, fallthrough_pc, 0);
         /* FIXME PR 307284: support client modifying, replacing, or adding
          * syscalls and ints: need to re-analyze.  Then we wouldn't
          * need the md->final_exit_flags field anymore.


### PR DESCRIPTION
This PR ports the dynamorio module to compile with Linux kernel 6.6

Summary of the main changes:
- Use `<linux/stddef.h>` and `<linux/srdarg.h>` in kernel builds.
- Fix compiler errors like `-Wimplicit-fallthrough` and `-Werror=enum-compare`.
- Update the callback function signature for `kallsyms_on_each_symbol`.
- Fix layout drifts in `struct module`, the memory of layout is now defined in `module->mem`. More importantly, different sections of a module are allocated separately and may not be in a continuous memory region.

Issue: #11