### PR TITLE
i#11: Enable scons in build

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -12,7 +12,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt update
-          sudo apt install libelf-dev
+          sudo apt install libelf-dev scons
 
       - name: Download and extract kernel source
         run: |

--- a/core/drk.mk
+++ b/core/drk.mk
@@ -21,9 +21,7 @@ MODULES_MAKE =-C $(KERNELDIR) M=$(DR_CORE_DIR)/kernel_linux/modules\
 
 ASM_FILES= $(shell find . -name '*.asm' | sed 's/\.asm/.S/g')
 
-# TODO i#11: re-enable scons to build utility programs and tests
-# default: exports.c api_headers scons $(ASM_FILES)
-default: exports.c api_headers $(ASM_FILES)
+default: exports.c api_headers scons $(ASM_FILES)
 	cp kernel_linux/modules/Module.symvers.in kernel_linux/modules/Module.symvers
 	$(MAKE) $(MODULES_MAKE) KBUILD_MODPOST_WARN=1 modules
 
@@ -52,8 +50,7 @@ $(API_INCLUDE_DIR): $(shell find . -name '*.h' | grep -v $(API_INCLUDE_DIR) | gr
 
 clean:
 	$(MAKE) $(MODULES_MAKE) clean
-# TODO i#11: Re-enable scons to build utility programs and tests
-#	scons -c
+	scons -c
 	rm -f $$(find . -name '*.S')
 	rm -f $$(find . -name '*.o')
 	rm -f $$(find . -name '.*.o.cmd')

--- a/core/kernel_linux/hypercall_host.cc
+++ b/core/kernel_linux/hypercall_host.cc
@@ -16,6 +16,7 @@ extern "C" {
 #include <sys/types.h>
 #include <time.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "linux_device.h"
 

--- a/core/kernel_linux/linux_device.cc
+++ b/core/kernel_linux/linux_device.cc
@@ -12,8 +12,8 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 
 using namespace std;

--- a/core/kernel_linux/linux_device.h
+++ b/core/kernel_linux/linux_device.h
@@ -1,5 +1,5 @@
 #ifndef __LINUX_DEVICE_H_
-#    define __LINUE_DEVICE_H_
+#    define __LINUX_DEVICE_H_
 
 #    include <string>
 

--- a/core/stats.h
+++ b/core/stats.h
@@ -214,7 +214,7 @@ extern timestamp_t kstat_ignore_context_switch;
 #        define KSTAT_DUMP_STACK(kstack)                                       \
             if ((kstack)->node[(kstack)->depth - 1].var !=                     \
                 &cur_dcontext->thread_kstats->vars_kstats.logging) {           \
-                LOG(THREAD_GET, LOG_STATS, 1, "ks %s:%d\n"__FILE__, __LINE__); \
+                LOG(THREAD_GET, LOG_STATS, 1, "ks %s:%d\n" __FILE__, __LINE__); \
                 kstats_dump_stack(cur_dcontext);                               \
             }
 #    endif

--- a/core/stdarg_wrapper.h
+++ b/core/stdarg_wrapper.h
@@ -3,7 +3,7 @@
 
 #include "configure.h"
 
-#ifdef LINUX_KERNEL
+#if defined(LINUX_KERNEL) && !defined(__USER_UNIT_TEST)
 #    include <linux/stdarg.h>
 #else
 #    include <stdarg.h>

--- a/core/utils_unittest.c
+++ b/core/utils_unittest.c
@@ -1,3 +1,4 @@
+typedef char bool;
 #include <sys/types.h>
 #include "configure.h"
 #include "globals.h"

--- a/core/utils_unittest.c
+++ b/core/utils_unittest.c
@@ -1,4 +1,3 @@
-typedef char bool;
 #include <sys/types.h>
 #include "configure.h"
 #include "globals.h"


### PR DESCRIPTION
Enabled scons build and clean in Makefile

Added missing headers:
- `<unistd.h>` is required for `unlink()` and `symlink()`
- `<sys/sysmacros.h>` is required for `major()` and `makedev()`

These functions were previously implicitly pulled in, but now anymore due to glibc changes.

Issue: #11 