### PR TITLE
i#11: Disable KBUILD_MODPOST_WARN when building the kernel modules

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   x86-64:
     runs-on: ubuntu-24.04
+    env:
+      MAKE: make -j$(nproc)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -25,8 +27,8 @@ jobs:
         working-directory: ${{ env.KERNEL_DIR }}
         run: |
           make defconfig
-          make -j$(nproc) vmlinux modules
+          $MAKE vmlinux modules
 
       - name: Build drk
         # TODO i#10: Convert to cmake.
-        run: cd core && make -j$(nproc) -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR
+        run: cd core && $MAKE -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 jobs:
   x86-64:
     runs-on: ubuntu-24.04
-    env:
-      MAKE: make -j$(nproc)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -15,6 +13,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libelf-dev scons
+          echo "MAKE=make -j$(nproc)" >> $GITHUB_ENV
 
       - name: Download and extract kernel source
         run: |

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libelf-dev scons
-          echo "MAKE=make -j$(nproc)" >> $GITHUB_ENV
+          echo "MAKE_CMD=make -j$(nproc)" >> $GITHUB_ENV
 
       - name: Download and extract kernel source
         run: |
@@ -26,8 +26,8 @@ jobs:
         working-directory: ${{ env.KERNEL_DIR }}
         run: |
           make defconfig
-          $MAKE vmlinux modules
+          $MAKE_CMD vmlinux modules
 
       - name: Build drk
         # TODO i#10: Convert to cmake.
-        run: cd core && $MAKE -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR
+        run: cd core && $MAKE_CMD -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -25,9 +25,9 @@ jobs:
         working-directory: ${{ env.KERNEL_DIR }}
         run: |
           make defconfig
-          make -j vmlinux
-          make -j modules
+          make -j$(nproc) vmlinux
+          make -j$(nproc) modules
 
       - name: Build drk
         # TODO i#10: Convert to cmake.
-        run: cd core && make -j -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR
+        run: cd core && make -j$(nproc) -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -25,8 +25,7 @@ jobs:
         working-directory: ${{ env.KERNEL_DIR }}
         run: |
           make defconfig
-          make -j$(nproc) vmlinux
-          make -j$(nproc) modules
+          make -j$(nproc) vmlinux modules
 
       - name: Build drk
         # TODO i#10: Convert to cmake.

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -25,8 +25,9 @@ jobs:
         working-directory: ${{ env.KERNEL_DIR }}
         run: |
           make defconfig
-          make modules_prepare
+          make -j vmlinux
+          make -j modules
 
       - name: Build drk
         # TODO i#10: Convert to cmake.
-        run: cd core && make -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR
+        run: cd core && make -j -f drk.mk KERNELDIR=$GITHUB_WORKSPACE/$KERNEL_DIR

--- a/core/drk.mk
+++ b/core/drk.mk
@@ -23,7 +23,7 @@ ASM_FILES= $(shell find . -name '*.asm' | sed 's/\.asm/.S/g')
 
 default: exports.c api_headers scons $(ASM_FILES)
 	cp kernel_linux/modules/Module.symvers.in kernel_linux/modules/Module.symvers
-	$(MAKE) $(MODULES_MAKE) KBUILD_MODPOST_WARN=1 modules
+	$(MAKE) $(MODULES_MAKE) modules
 
 scons:
 	scons -j10

--- a/core/exports.py
+++ b/core/exports.py
@@ -17,6 +17,7 @@ def check_open(args):
 
 def excluded_functions():
     return {
+        "__attribute__",
         "dr_init",
         "dr_smp_exit",
         "dr_get_app_PEB",
@@ -65,8 +66,8 @@ def main():
     functions = set()
     for path in glob.glob(f"{sys.argv[1]}/*.h"):
         code = check_open(f"cpp -DX86_64 -DLINUX -DLINUX_KERNEL {path}".split())
-        for match in re.findall("(^[a-zA-Z0-9_]+)(\(.*)$", code, re.MULTILINE):
-            functions.add(match[0])
+        for match in re.findall(r"^\s*(?:[a-zA-Z0-9_]+\s+)*([a-zA-Z0-9_]+)\(", code, re.MULTILINE):
+            functions.add(match)
     # This is a dirty hack. We don't export certain functions that aren't #
     # implemented. The lib/genapi.pl script should probably be modified to not include
     # functions that are IFDEF'd out.

--- a/core/exports.py
+++ b/core/exports.py
@@ -63,10 +63,14 @@ def extra_symbols():
 
 def main():
     assert len(sys.argv) == 2
+    # TODO i#10: The current approach of discovering and exporting functions using
+    # regular expressions is hacky. It should be replaced when moving to CMake.
     functions = set()
     for path in glob.glob(f"{sys.argv[1]}/*.h"):
         code = check_open(f"cpp -DX86_64 -DLINUX -DLINUX_KERNEL {path}".split())
-        for match in re.findall(r"^\s*(?:[a-zA-Z0-9_]+\s+)*([a-zA-Z0-9_]+)\(", code, re.MULTILINE):
+        for match in re.findall(
+            r"^\s*(?:[a-zA-Z0-9_]+\s+)*([a-zA-Z0-9_]+)\(", code, re.MULTILINE
+        ):
             functions.add(match)
     # This is a dirty hack. We don't export certain functions that aren't #
     # implemented. The lib/genapi.pl script should probably be modified to not include

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -142,8 +142,8 @@ kernel_module_init(size_t dr_heap_size)
      * this kprobe trick to resolve its address.
      * NOTE: This requires the kernel to be configured with CONFIG_KPROBES=y.
      * If this becomes an issue, an alternative is to parse the address from
-     * /proc/kallsyms in user space and pass it into the kernel module as
-     * module parameters.
+     * /proc/kallsyms in user space and pass it into the kernel module as a
+     * module parameter.
      */
     struct kprobe kp = {
         .symbol_name = "kallsyms_lookup_name",

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -5,6 +5,7 @@
 #include <linux/percpu.h>
 #include <linux/smp.h>
 #include <linux/kallsyms.h>
+#include <linux/kprobes.h>
 #include <linux/sched.h>
 #include <linux/mm.h>
 
@@ -76,25 +77,17 @@ done:
     kfree(buffer);
 }
 
-static int
-find_kernel_symbol_callback(void *data, const char *name, unsigned long address)
-{
-    kernel_symbol_t *symbol = (kernel_symbol_t *)data;
-    if (strcmp(name, symbol->name) == 0) {
-        symbol->address = address;
-        get_symbol_size(symbol);
-        return 1;
-    }
-    return 0;
-}
+static unsigned long (*kallsyms_lookup_name_ptr)(const char *name) = NULL;
 
 static bool
 find_kernel_symbol(kernel_symbol_t *symbol)
 {
-    if (kallsyms_on_each_symbol(find_kernel_symbol_callback, symbol)) {
+    symbol->address = kallsyms_lookup_name_ptr(symbol->name);
+    if (symbol->address != 0) {
+        get_symbol_size(symbol);
         return true;
     }
-    printk("find_kernel_symbol failed for %s\n", symbol->name);
+    printk("find_kernel_symbol failed for %s.\n", symbol->name);
     return false;
 }
 
@@ -145,6 +138,31 @@ static struct module *(*__module_address_ptr)(unsigned long addr) = NULL;
 bool
 kernel_module_init(size_t dr_heap_size)
 {
+    /* kallsyms_lookup_name is unexported in newer kernels (5.7+), so we use
+     * this kprobe trick to resolve its address.
+     * NOTE: This requires the kernel to be configured with CONFIG_KPROBES=y.
+     * If this becomes an issue, an alternative is to parse the address from
+     * /proc/kallsyms in user space and pass it into the kernel module as
+     * module parameters.
+     */
+    struct kprobe kp = {
+        .symbol_name = "kallsyms_lookup_name",
+    };
+
+    if (register_kprobe(&kp) < 0) {
+        printk("Failed to register kprobe for kallsyms_lookup_name.\n");
+        return false;
+    }
+
+    if (kp.addr == NULL) {
+        printk("kprobe registered for kallsyms_lookup_name but the address is NULL.\n");
+        unregister_kprobe(&kp);
+        return false;
+    }
+
+    kallsyms_lookup_name_ptr = (void *)kp.addr;
+    unregister_kprobe(&kp);
+
 #ifdef HYPERCALL_DEBUGGING
     if (!hypercall_init()) {
         return false;


### PR DESCRIPTION
Before we were building the kernel module with `KBUILD_MODPOST_WARN=1`, which means when `modpost` can not find an unresolved symbol in `Module.symvers` it only triggers a warning instead of an error. We had `KBUILD_MODPOST_WARN` enabled because we wanted an initial minimal passing build, but it also means some bugs can be missed. For example, the code has been using `kallsyms_on_each_symbol`, which has been unexported since kernel 5.7, but it only triggers a warning instead of an error. Now that most of the code base have been updated to compile with kernel 6.6, I'm turning `KBUILD_MODPOST_WARN` off in this PR.

The other changes included in this PR are to fix build failures with `KBUILD_MODPOST_WARN` off:
1. Build `vmlinux` and `Module.symvers`.
  Before we were only generating the kernel headers with `make modules_prepare`, but now we need the `Module.symvers` file from the kernel, which in turn requires `vmlinux` to be built.

2. Dynamically resolve unexported kernel symbols using kprobe, and switch from `kallsyms_on_each_symbol` to `kallsyms_lookup_name`.
  Both `kallsyms_on_each_symbol` and `kallsyms_lookup_name` have been unexported since kernel 5.7.
  https://github.com/torvalds/linux/commit/0bd476e6c67190b5eb7b6e105c8db8ff61103281
  So we have to dynamically resolve the address using `kprobe`.
  While we are at it, I'm also switching from `kallsyms_on_each_symbol` to `kallsyms_lookup_name` to dynamically resolve kernel symbols. This is because `kallsyms_lookup_name` is more efficient and requires less boilerplate code (the callback function).

3. Improve function detection regex
  The regular expression in `exports.py` assumes that the function name is always the first symbol on a line. However clang-format doesn't always format code this way: sometime the return type and the function name is placed on the same line. In this case, the function will fail to be exported. This change updated the regular expression to also cover those scenarios.
  However, after the regular expression change, it will now also match `__attribute__` and try to export it, which would cause an error. So it's also added to the `excluded_functions` list.
  Ultimately, I think detecting and exporting function via python scripts and regular expressions is hacky. We should do it the proper way when moving the build system to `cmake` using visibility attributes. I added a comment in #10.

Issue #11 
