### PR TITLE
i#29: Set drk heap memory as executable after allocation

### DIFF
--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -223,6 +223,25 @@ kernel_module_init(size_t dr_heap_size)
      * by default to adhere to strict W^X policies. We must explicitly mark
      * the allocated heap as executable using set_memory_x, so DynamoRIO can
      * store its code cache.
+     *
+     * NOTE: We must mark the entire heap as executable at module load time
+     * (where interrupts are enabled) rather than dynamically toggling page
+     * permissions at runtime via os_heap_commit. This is because DynamoRIO's
+     * thread takeover and dynamic allocations often occur in contexts where
+     * interrupts are disabled. Modifying page tables at runtime in these
+     * contexts would require sending Inter-Processor Interrupts (IPIs) to flush
+     * TLBs across other cores, which is forbidden when interrupts are disabled
+     * and would trigger an immediate kernel panic or system deadlock.
+     *
+     * TODO i#32: We would need to allocate two separate memory heaps at startup
+     * for fine-grained W^X protection:
+     *   1) An executable code heap (marked +x).
+     *   2) A non-executable data heap (left NX).
+     * Since page permissions are set at startup (when interrupts are enabled),
+     * no runtime permission changes are needed. This requires modifying the VMM
+     * (core/heap.c) to support two concurrent VMM regions instead of a single
+     * one, routing executable allocations to the code heap and non-executable
+     * allocations to the data heap.
      */
     int ret = set_memory_x_ptr((unsigned long)heap, heap_size / PAGE_SIZE);
     if (ret != 0) {

--- a/core/kernel_linux/kernel_interface.c
+++ b/core/kernel_linux/kernel_interface.c
@@ -138,6 +138,7 @@ static void *(*module_alloc_ptr)(unsigned long) = NULL;
 static unsigned long (*module_kallsyms_lookup_name_ptr)(const char *name) = NULL;
 static struct module *(*find_module_ptr)(const char *name) = NULL;
 static struct module *(*__module_address_ptr)(unsigned long addr) = NULL;
+static int (*set_memory_x_ptr)(unsigned long, int) = NULL;
 
 bool
 kernel_module_init(size_t dr_heap_size)
@@ -196,6 +197,10 @@ kernel_module_init(size_t dr_heap_size)
     if (__module_address_ptr == NULL) {
         return false;
     }
+    set_memory_x_ptr = find_kernel_symbol_address("set_memory_x");
+    if (set_memory_x_ptr == NULL) {
+        return false;
+    }
 
     /* Use module_alloc so the heap is located close (i.e., 32-bit reachable) to
      * the module's text and data. The Linux kernel allocates only 1.5 GB of
@@ -212,7 +217,19 @@ kernel_module_init(size_t dr_heap_size)
     if (heap == NULL) {
         printk("Failed to allocate %luB using module_alloc.\n", heap_size);
         return false;
-        ;
+    }
+
+    /* In modern kernels, module_alloc allocates memory as non-executable (NX)
+     * by default to adhere to strict W^X policies. We must explicitly mark
+     * the allocated heap as executable using set_memory_x, so DynamoRIO can
+     * store its code cache.
+     */
+    int ret = set_memory_x_ptr((unsigned long)heap, heap_size / PAGE_SIZE);
+    if (ret != 0) {
+        printk("set_memory_x failed with error %d\n", ret);
+        vfree(heap);
+        heap = NULL;
+        return false;
     }
     return true;
 }


### PR DESCRIPTION
Modern kernels implement W^X (Write XOR Execute), so the heap memory allocated by `module_alloc()` is non-executable by default, this causes an assertion failure as well as a kernel panic. This change sets the allocated heap memory as executable using the `set_memory_x()` function in the kernel.

Fixes #29 